### PR TITLE
Made batch file more robust with certain paths

### DIFF
--- a/test/bin-debug/packageWin.bat
+++ b/test/bin-debug/packageWin.bat
@@ -1,5 +1,5 @@
-SET AIR_SDK=%USERPROFILE%\Documents\AdobeAIRSDK
-set STEAM_SDK=%USERPROFILE%\Documents\Steam\sdk
+SET "AIR_SDK=%USERPROFILE%\Documents\AdobeAIRSDK"
+set "STEAM_SDK=%USERPROFILE%\Documents\Steam\sdk"
 SET ANE_PATH=..\..\lib\bin
 
 copy "%STEAM_SDK%\redistributable_bin\steam_api.dll" .


### PR DESCRIPTION
If the user's profile path contains `&` the batch file wouldn't work anymore. Quoting the argument to `set` solves this.
