### PR TITLE
Fix compilation error regarding snprintf in VS2015.

### DIFF
--- a/src/CSteam/CSteam.h
+++ b/src/CSteam/CSteam.h
@@ -11,7 +11,7 @@
 #ifndef CSTEAM_H
 #define CSTEAM_H
 
-#if defined(WIN32)
+#if (defined(_MSC_VER) && (_MSC_VER < 1900))
 	#define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
Add a check for VS2013 and earlier before defining snprintf.